### PR TITLE
picard-plugins: Use install instead of cp and mkdir.

### DIFF
--- a/_musicbrainz/picard-plugins/PKGBUILD
+++ b/_musicbrainz/picard-plugins/PKGBUILD
@@ -57,21 +57,21 @@ md5sums=('d1fbefffcd49da2dd6f335be2ff44d69'
 package() {
   plugindir="${pkgdir}/usr/lib/python2.7/site-packages/picard/plugins"
   cd "$srcdir"
-  mkdir -p "$plugindir"
-  cp \
+  install -d "$plugindir"
+  install -m644 -t "$plugindir" \
     addrelease.py classicdiscnumber.py cuesheet.py discnumber.py \
     featartist.py featartistsintitles.py coverart.py no_release.py \
     open_in_gui.py release_type.py swapprefix.py \
-    titlecase.py tracks2clipboard.py \
-    "$plugindir"
-  mkdir -p "$plugindir/lastfm"
-  cp lastfm_init.py "$plugindir/lastfm/__init__.py"
-  mkdir -p "$plugindir/lastfmplus"
-  cp  lastfmplus_options.py "$plugindir/lastfmplus/ui_options_lastfm.py"
-  cp lastfmplus_init.py "$plugindir/lastfmplus/__init__.py"
-  mkdir -p "$plugindir/replaygain"
-  cp ui_options_replaygain.py options_replaygain.ui "$plugindir/replaygain"
-  cp replaygain_init.py "$plugindir/replaygain/__init__.py"
+    titlecase.py tracks2clipboard.py
+  install -d "$plugindir/lastfm"
+  install -m644 -T lastfm_init.py "$plugindir/lastfm/__init__.py"
+  install -d "$plugindir/lastfmplus"
+  install -m644 -T lastfmplus_options.py "$plugindir/lastfmplus/ui_options_lastfm.py"
+  install -m644 -T lastfmplus_init.py "$plugindir/lastfmplus/__init__.py"
+  install -d "$plugindir/replaygain"
+  install -m644 -t "$plugindir/replaygain" \
+    ui_options_replaygain.py options_replaygain.ui
+  install -m644 -T replaygain_init.py "$plugindir/replaygain/__init__.py"
 }
 
 # vim:set ts=2 sw=2 et:


### PR DESCRIPTION
Per @gtmanfred's comment on the AUR page: https://aur.archlinux.org/packages/picard-plugins/
